### PR TITLE
fix: setstate called after dispose

### DIFF
--- a/lib/cached_network_svg_image.dart
+++ b/lib/cached_network_svg_image.dart
@@ -117,10 +117,12 @@ class _CachedNetworkSVGImageState extends State<CachedNetworkSVGImage>
       _controller.forward();
     } catch (e) {
       log('CachedNetworkSVGImage: $e');
-      setState(() {
-        _isError = true;
-        _isLoading = false;
-      });
+      if(mounted) {
+        setState(() {
+          _isError = true;
+          _isLoading = false;
+        });
+      }
     }
   }
 


### PR DESCRIPTION
The setState() call inside _loadImage() function. Was throwing an error in scenarios where the screen has already been disposed. So, I added a mounted check to prevent the call when the widget is already gone. It won't affect any situation where the widget is active.