### PR TITLE
remove plugins from pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,15 +19,3 @@ dev_dependencies:
   flutter_lints: ^2.0.0
 
 flutter:
-  plugin:
-    platforms:
-      android:
-        default_package: cached_network_svg_image
-      ios:
-        default_package: cached_network_svg_image
-      macos:
-        default_package: cached_network_svg_image
-      windows:
-        default_package: cached_network_svg_image
-      linux:
-        default_package: cached_network_svg_image


### PR DESCRIPTION
When using flutter on the beta branch, users will get these warnings:

```

Package cached_network_svg_image:android references cached_network_svg_image:android as the default plugin, but it does not provide an inline implementation.
Ask the maintainers of cached_network_svg_image to either avoid referencing a default implementation via `platforms: android: default_package: cached_network_svg_image` or add an inline implementation to cached_network_svg_image via `platforms: android:` `pluginClass` or `dartPluginClass`.

Package cached_network_svg_image:ios references cached_network_svg_image:ios as the default plugin, but it does not provide an inline implementation.
Ask the maintainers of cached_network_svg_image to either avoid referencing a default implementation via `platforms: ios: default_package: cached_network_svg_image` or add an inline implementation to cached_network_svg_image via `platforms: ios:` `pluginClass` or `dartPluginClass`.

Package cached_network_svg_image:linux references cached_network_svg_image:linux as the default plugin, but it does not provide an inline implementation.
Ask the maintainers of cached_network_svg_image to either avoid referencing a default implementation via `platforms: linux: default_package: cached_network_svg_image` or add an inline implementation to cached_network_svg_image via `platforms: linux:` `pluginClass` or `dartPluginClass`.

Package cached_network_svg_image:macos references cached_network_svg_image:macos as the default plugin, but it does not provide an inline implementation.
Ask the maintainers of cached_network_svg_image to either avoid referencing a default implementation via `platforms: macos: default_package: cached_network_svg_image` or add an inline implementation to cached_network_svg_image via `platforms: macos:` `pluginClass` or `dartPluginClass`.

Package cached_network_svg_image:windows references cached_network_svg_image:windows as the default plugin, but it does not provide an inline implementation.
Ask the maintainers of cached_network_svg_image to either avoid referencing a default implementation via `platforms: windows: default_package: cached_network_svg_image` or add an inline implementation to cached_network_svg_image via `platforms: windows:` `pluginClass` or `dartPluginClass`.

Package cached_network_svg_image:android references cached_network_svg_image:android as the default plugin, but it does not provide an inline implementation.
Ask the maintainers of cached_network_svg_image to either avoid referencing a default implementation via `platforms: android: default_package: cached_network_svg_image` or add an inline implementation to cached_network_svg_image via `platforms: android:` `pluginClass` or `dartPluginClass`.

Package cached_network_svg_image:ios references cached_network_svg_image:ios as the default plugin, but it does not provide an inline implementation.
Ask the maintainers of cached_network_svg_image to either avoid referencing a default implementation via `platforms: ios: default_package: cached_network_svg_image` or add an inline implementation to cached_network_svg_image via `platforms: ios:` `pluginClass` or `dartPluginClass`.

Package cached_network_svg_image:linux references cached_network_svg_image:linux as the default plugin, but it does not provide an inline implementation.
Ask the maintainers of cached_network_svg_image to either avoid referencing a default implementation via `platforms: linux: default_package: cached_network_svg_image` or add an inline implementation to cached_network_svg_image via `platforms: linux:` `pluginClass` or `dartPluginClass`.

Package cached_network_svg_image:macos references cached_network_svg_image:macos as the default plugin, but it does not provide an inline implementation.
Ask the maintainers of cached_network_svg_image to either avoid referencing a default implementation via `platforms: macos: default_package: cached_network_svg_image` or add an inline implementation to cached_network_svg_image via `platforms: macos:` `pluginClass` or `dartPluginClass`.

Package cached_network_svg_image:windows references cached_network_svg_image:windows as the default plugin, but it does not provide an inline implementation.
Ask the maintainers of cached_network_svg_image to either avoid referencing a default implementation via `platforms: windows: default_package: cached_network_svg_image` or add an inline implementation to cached_network_svg_image via `platforms: windows:` `pluginClass` or `dartPluginClass`.

Package cached_network_svg_image:android references cached_network_svg_image:android as the default plugin, but it does not provide an inline implementation.
Ask the maintainers of cached_network_svg_image to either avoid referencing a default implementation via `platforms: android: default_package: cached_network_svg_image` or add an inline implementation to cached_network_svg_image via `platforms: android:` `pluginClass` or `dartPluginClass`.

Package cached_network_svg_image:ios references cached_network_svg_image:ios as the default plugin, but it does not provide an inline implementation.
Ask the maintainers of cached_network_svg_image to either avoid referencing a default implementation via `platforms: ios: default_package: cached_network_svg_image` or add an inline implementation to cached_network_svg_image via `platforms: ios:` `pluginClass` or `dartPluginClass`.

Package cached_network_svg_image:linux references cached_network_svg_image:linux as the default plugin, but it does not provide an inline implementation.
Ask the maintainers of cached_network_svg_image to either avoid referencing a default implementation via `platforms: linux: default_package: cached_network_svg_image` or add an inline implementation to cached_network_svg_image via `platforms: linux:` `pluginClass` or `dartPluginClass`.

Package cached_network_svg_image:macos references cached_network_svg_image:macos as the default plugin, but it does not provide an inline implementation.
Ask the maintainers of cached_network_svg_image to either avoid referencing a default implementation via `platforms: macos: default_package: cached_network_svg_image` or add an inline implementation to cached_network_svg_image via `platforms: macos:` `pluginClass` or `dartPluginClass`.

Package cached_network_svg_image:windows references cached_network_svg_image:windows as the default plugin, but it does not provide an inline implementation.
Ask the maintainers of cached_network_svg_image to either avoid referencing a default implementation via `platforms: windows: default_package: cached_network_svg_image` or add an inline implementation to cached_network_svg_image via `platforms: windows:` `pluginClass` or `dartPluginClass`.

```

This was introduced in https://github.com/flutter/flutter/pull/137040

Since this is a pure dart package with not native code, the `plugins` section in pubspec.yaml is not needed anyway. 
This PR removes section.
